### PR TITLE
Add CG residual helper and test

### DIFF
--- a/tests/test_cg.py
+++ b/tests/test_cg.py
@@ -1,0 +1,15 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from util import cg_residuals
+
+
+def test_cg_residuals_basic():
+    eps = 0.5
+    m = 32
+    k = 2
+    res = cg_residuals(eps, m, k)
+    assert res, "No residuals returned"
+    assert res[-1] < 1e-14

--- a/util.py
+++ b/util.py
@@ -1,5 +1,6 @@
 import numpy as np
 from scipy.sparse import diags
+from scipy.sparse.linalg import cg
 
 
 def chebyshev_diagonal_spd(n: int, eps: float = 1e-8):
@@ -34,3 +35,37 @@ def chebyshev_diagonal_spd(n: int, eps: float = 1e-8):
         nodes = np.cos(np.pi * k / (n - 1))
         diag = 0.5 * (1 - eps) * nodes + 0.5 * (1 + eps)
     return diags(diag, offsets=0, format="csr")
+
+
+def cg_residuals(eps: float, m: int, k: int):
+    """Run CG on ``chebyshev_diagonal_spd(m, eps)`` and record residuals.
+
+    Parameters
+    ----------
+    eps : float
+        Lower bound for the eigenvalues used to construct ``A``.
+    m : int
+        Dimension of ``A`` and the right-hand side ``b``.
+    k : int
+        Number of leading entries of ``b`` to zero out.
+
+    Returns
+    -------
+    list[float]
+        Euclidean norms of the residual at each iteration of CG.
+    """
+
+    A = chebyshev_diagonal_spd(m, eps)
+    b = np.ones(m)
+    if k:
+        b[:k] = 0.0
+    b /= np.linalg.norm(b)
+
+    residuals: list[float] = []
+
+    def callback(xk: np.ndarray) -> None:
+        r = b - A.dot(xk)
+        residuals.append(np.linalg.norm(r))
+
+    cg(A, b, atol=0.0, rtol=1e-14, callback=callback)
+    return residuals


### PR DESCRIPTION
## Summary
- add `cg_residuals` helper for running conjugate gradient and recording residuals
- test that the residuals fall below tolerance for a small problem

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869c366464c83289bf94fa8cc515e7d