### PR TITLE
Add CG residual experiment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,6 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# Experiment outputs
+experiments/*.svg

--- a/experiments/compare_residuals.py
+++ b/experiments/compare_residuals.py
@@ -1,0 +1,32 @@
+"""Plot residuals for different deflation parameters using CG."""
+
+import matplotlib.pyplot as plt
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from util import cg_residuals
+
+
+def main() -> None:
+    eps = 1e-3
+    m = 1024
+    ks = [0, 1, 4, 16]
+
+    plt.figure()
+    for k in ks:
+        res = cg_residuals(eps, m, k)
+        plt.semilogy(res, label=f"k={k}")
+    plt.xlabel("iteration")
+    plt.ylabel("residual norm")
+    plt.legend()
+    plt.tight_layout()
+
+    out_path = Path(__file__).with_name("residuals.svg")
+    plt.savefig(out_path, format="svg")
+    print(f"wrote {out_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- ignore experiment output SVG files
- add experiment script to run CG with different `k` values

## Testing
- `pytest -q`
- `python experiments/compare_residuals.py`

------
https://chatgpt.com/codex/tasks/task_e_6869c527a8a88328962d85189cd04eb0