### PR TITLE
Add R^2 output to regression experiment

### DIFF
--- a/experiments/regression_experiment.py
+++ b/experiments/regression_experiment.py
@@ -40,9 +40,16 @@ def run_experiment(samples: int, eps_exp_low: float, eps_exp_high: float,
     X_design = np.column_stack([np.ones(len(y)), X])
     beta, *_ = np.linalg.lstsq(X_design, y, rcond=None)
 
+    y_pred = X_design @ beta
+    ss_res = np.sum((y - y_pred) ** 2)
+    ss_tot = np.sum((y - y.mean()) ** 2)
+    r2 = 1.0 - ss_res / ss_tot if ss_tot else float("nan")
+
     names = ["intercept", "log_eps", "log_m", "k/m"]
     for name, b in zip(names, beta):
         print(f"{name}: {b}")
+
+    print(f"R^2: {r2}")
 
 
 def main() -> None:

--- a/tests/test_regression_experiment.py
+++ b/tests/test_regression_experiment.py
@@ -8,3 +8,4 @@ def test_regression_experiment_runs(tmp_path):
     cmd = [sys.executable, str(script), "--samples", "3", "--eps-exp-low", "-3", "--eps-exp-high", "-2", "--m-exp-low", "1", "--m-exp-high", "2", "--seed", "0"]
     result = subprocess.run(cmd, capture_output=True, text=True, check=True)
     assert "intercept" in result.stdout
+    assert "R^2" in result.stdout


### PR DESCRIPTION
## Summary
- compute predictions for regression experiment and show R^2 metric
- check for R^2 in regression experiment test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869d13f5754832895cd6b78b586f667